### PR TITLE
Add support for not counting clicks from CIDRs/IP addresses (hardcoded or obtained from a `whois` lookup on an ASN)

### DIFF
--- a/lib/php-cidr-match/.gitignore
+++ b/lib/php-cidr-match/.gitignore
@@ -1,0 +1,7 @@
+build/*
+vendor/
+composer.lock
+.project
+.settings
+.DS_Store
+.idea

--- a/lib/php-cidr-match/.travis.yml
+++ b/lib/php-cidr-match/.travis.yml
@@ -1,0 +1,27 @@
+language: php
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+
+before_script:
+  - wget http://getcomposer.org/composer.phar
+  - php composer.phar install --dev
+
+script:
+  - cd ./tests/
+  - ../vendor/bin/phpunit
+
+after_script:
+  - ../vendor/bin/ocular code-coverage:upload --format=php-clover ../build/logs/clover.xml
+
+notifications:
+  email: false
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 5.6
+    - php: hhvm

--- a/lib/php-cidr-match/CIDRmatch/CIDRmatch.php
+++ b/lib/php-cidr-match/CIDRmatch/CIDRmatch.php
@@ -1,0 +1,97 @@
+<?php
+namespace CIDRmatch;
+
+/** CIDR match
+ * ================================================================================
+ * IDRmatch is a library to match an IP to an IP range in CIDR notation (IPv4 and
+ * IPv6).
+ *  ================================================================================
+ * @package     CIDRmatch
+ * @author      Thomas Lutz
+ * @copyright   Copyright (c) 2015 - present Thomas Lutz
+ * @license     http://tholu.mit-license.org
+ *  ================================================================================
+ */
+
+class CIDRmatch
+{
+
+    public function match($ip, $cidr)
+    {
+        list($subnet, $mask) = explode('/', $cidr);
+
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            // it's valid
+            $ipVersion = 'v4';
+        } else {
+            // it's not valid
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+                // it's valid
+                $ipVersion = 'v6';
+            } else {
+                // it's not valid
+                return false;
+            }
+        }
+
+        switch ($ipVersion) {
+            case 'v4':
+                return $this->IPv4Match($ip, $subnet, $mask);
+                break;
+            case 'v6':
+                return $this->IPv6Match($ip, $subnet, $mask);
+                break;
+        }
+    }
+
+    // inspired by: http://stackoverflow.com/questions/7951061/matching-ipv6-address-to-a-cidr-subnet
+    private function IPv6MaskToByteArray($subnetMask)
+    {
+        $addr = str_repeat("f", $subnetMask / 4);
+        switch ($subnetMask % 4) {
+            case 0:
+                break;
+            case 1:
+                $addr .= "8";
+                break;
+            case 2:
+                $addr .= "c";
+                break;
+            case 3:
+                $addr .= "e";
+                break;
+        }
+        $addr = str_pad($addr, 32, '0');
+        $addr = pack("H*", $addr);
+
+        return $addr;
+    }
+
+    // inspired by: http://stackoverflow.com/questions/7951061/matching-ipv6-address-to-a-cidr-subnet
+    private function IPv6Match($address, $subnetAddress, $subnetMask)
+    {
+        if (!filter_var($subnetAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) || $subnetMask === NULL || $subnetMask === "" || $subnetMask < 0 || $subnetMask > 128) {
+            return false;
+        }
+        $subnet = inet_pton($subnetAddress);
+        $addr = inet_pton($address);
+
+        $binMask = $this->IPv6MaskToByteArray($subnetMask);
+
+        return ($addr & $binMask) == $subnet;
+    }
+
+    // inspired by: http://stackoverflow.com/questions/594112/matching-an-ip-to-a-cidr-mask-in-php5
+    private function IPv4Match($address, $subnetAddress, $subnetMask)
+    {
+        if (!filter_var($subnetAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) || $subnetMask === NULL || $subnetMask === "" || $subnetMask < 0 || $subnetMask > 32) {
+            return false;
+        }
+        if ((ip2long($address) & ~((1 << (32 - $subnetMask)) - 1)) == ip2long($subnetAddress)) {
+            return true;
+        }
+
+        return false;
+    }
+
+}

--- a/lib/php-cidr-match/LICENSE.txt
+++ b/lib/php-cidr-match/LICENSE.txt
@@ -1,0 +1,8 @@
+The MIT License (http://tholu.mit-license.org/)
+Copyright © 2015 Thomas Lutz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/php-cidr-match/README.md
+++ b/lib/php-cidr-match/README.md
@@ -1,0 +1,21 @@
+[![Build Status](https://travis-ci.org/tholu/php-cidr-match.svg?branch=master)](https://travis-ci.org/tholu/php-cidr-match)
+
+# CIDR match
+
+CIDRmatch is a library to match an IP to an IP range in CIDR notation (IPv4 and IPv6).
+
+NOTE: Symfony2 already does everything this library here does with its IpUtils module.
+Unfortunately I discovered this only after I finished working on this library.
+
+## Usage
+
+```
+$cidrMatch = new CIDRmatch();
+$cidrMatch->match($ip, $cidr);
+```
+
+## Tests
+
+```
+vendor/bin/phpunit tests/CIDRmatchTest
+```

--- a/lib/php-cidr-match/composer.json
+++ b/lib/php-cidr-match/composer.json
@@ -1,0 +1,32 @@
+{
+  "name" : "tholu/php-cidr-match",
+  "type" : "library",
+  "description" : "CIDRmatch is a library to match an IP to an IP range in CIDR notation (IPv4 and IPv6).",
+  "keywords" : [
+    "PHP",
+    "IPv4",
+    "IPv6",
+    "CIDR"
+  ],
+  "license" : "MIT",
+  "authors" : [{
+    "name" : "Thomas Lutz",
+    "email" : "thomaslutz.de@gmail.com",
+    "homepage" : "https://github.com/tholu",
+    "role" : "Creator, Developer, Maintainer"
+  }
+  ],
+  "require" : {
+    "php" : ">=5.3"
+  },
+  "require-dev" : {
+    "squizlabs/php_codesniffer" : "~1",
+    "composer/composer": "1.0.*@dev",
+    "phpunit/phpunit" : ">=3.7,<4"
+  },
+  "autoload" : {
+    "psr-0" : {
+      "CIDRmatch\\" : ""
+    }
+  }
+}

--- a/lib/php-cidr-match/tests/CIDRmatchTest/CIDRmatchTest.php
+++ b/lib/php-cidr-match/tests/CIDRmatchTest/CIDRmatchTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use CIDRmatch\CIDRmatch;
+require_once("CIDRmatch/CIDRmatch.php");
+
+/**
+ * A suite of tests for the CIDRmatch class
+ *
+ * @author Thomas Lutz
+ */
+class CIDRmatchTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Ensure that IPv4 addresses match
+     */
+    public function testIPv4Match()
+    {
+        $cidrMatch = new CIDRmatch();
+        $this->assertTrue($cidrMatch->match('104.132.31.99', '104.132.0.0/14'));
+        $this->assertTrue($cidrMatch->match('74.125.60.99', '74.125.0.0/16'));
+
+    }
+
+    /**
+     * Ensure that IPv4 addresses don't match with invalid input
+     */
+    public function testIPv4NoMatch()
+    {
+        $cidrMatch = new CIDRmatch();
+        $this->assertFalse($cidrMatch->match('Not an IP address', '104.132.0.0/14'));
+        $this->assertFalse($cidrMatch->match('104.132.31.99', 'Not an IP address/14'));
+        $this->assertFalse($cidrMatch->match('104.132.31.99', '104.132.0.0/33'));
+        $this->assertFalse($cidrMatch->match('104.132.31.99', '104.132.0.0/'));
+        $this->assertFalse($cidrMatch->match('104.132.31.99', '104.132.0.0'));
+    }
+
+    /**
+     * Ensure that IPv6 addresses match
+     */
+    public function testIPv6Match()
+    {
+        $cidrMatch = new CIDRmatch();
+        $this->assertTrue($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3::/64'));
+        $this->assertTrue($cidrMatch->match('2a00:1450:400c:c04::6a', '2a00:1450::/32'));
+    }
+
+    /**
+     * Ensure that IPv6 addresses don't match with invalid input
+     */
+    public function testIPv6NoMatch()
+    {
+        $cidrMatch = new CIDRmatch();
+        $this->assertFalse($cidrMatch->match('Not an IP address', '2001:0db8:85a3:08d3::/64'));
+        $this->assertFalse($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', 'Not an IP address/64'));
+        $this->assertFalse($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3::/129'));
+        $this->assertFalse($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3::/'));
+        $this->assertFalse($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3::'));
+    }
+
+
+}

--- a/lib/php-cidr-match/tests/bootstrap.php
+++ b/lib/php-cidr-match/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+$loader = require __DIR__.'/../vendor/autoload.php';
+
+error_reporting(E_ALL);

--- a/lib/php-cidr-match/tests/phpunit.xml
+++ b/lib/php-cidr-match/tests/phpunit.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="./bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         verbose="false"
+        >
+
+    <testsuites>
+        <testsuite name="CIDRmatch Test Suite">
+            <directory>./CIDRmatchTest</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">../CIDRmatch</directory>
+        </whitelist>
+        <blacklist>
+        </blacklist>
+    </filter>
+
+    <logging>
+        <log type="coverage-text" target="php://stdout"/>
+        <log type="coverage-clover" target="../build/logs/clover.xml"/>
+    </logging>
+</phpunit>


### PR DESCRIPTION
This is particularly useful for entities like Facebook that do a *lot* of scraping and usually don't send a helpful user agent string. These changes periodically (configured to be daily) look up the CIDRs (IP addresses) of Facebook's scrapers and store them for comparison against client IP addresses. Note that the frequent updates to the CIDRs (IP addresses) are required because Facebook's IP address pool changes frequently.